### PR TITLE
fix missing contact and snmp settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Role Variables
 # defaults file for ansible-observium
 observium_admin_account_info:
   email: 'observium@{{ pri_domain_name }}'
+  email_to: 'root@localhost'
+  email_default_only: 'TRUE'
   level: 10
   password: 'observium'
   username: 'admin'
@@ -72,6 +74,8 @@ observium_dl_package: 'observium-community-latest.tar.gz'
 observium_dl_url: 'http://www.observium.org'
 observium_monitor_libvirt_vms: false  #Define if desired to monitor LibVirt VM's
 pri_domain_name: 'vagrant.local'
+observium_snmp_community_list:   # define a list of default communities to try when adding devices
+  - '"public"'    # requires that the quotes are inside single quotation marks to keep the quotes in the config.php
 ````
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file for ansible-observium
 observium_admin_account_info:
   email: 'observium@{{ pri_domain_name }}'
+  email_to: 'root@localhost'
+  email_default_only: 'TRUE'
   level: 10
   password: 'observium'
   username: 'admin'
@@ -37,3 +39,5 @@ observium_dl_package: 'observium-community-latest.tar.gz'
 observium_dl_url: 'http://www.observium.org'
 observium_monitor_libvirt_vms: false  #Define if desired to monitor LibVirt VM's
 pri_domain_name: 'vagrant.local'
+observium_snmp_community_list:   # define a list of default communities to try when adding devices
+  - '"public"'    # requires that the quotes are inside single quotation marks to keep the quotes in the config.php

--- a/templates/config.php.j2
+++ b/templates/config.php.j2
@@ -13,7 +13,7 @@ $config['db_name']      = '{{ observium_db_info.db }}';
 #$config['install_dir'] = "{{ observium_base_dir }}";
 
 // Default community list to use when adding/discovering
-$config['snmp']['community'] = array("public");
+$config['snmp']['community'] = array({{ observium_snmp_community_list | join(',') }});
 
 // Authentication Model
 $config['auth_mechanism'] = "mysql";    // default, other options: ldap, http-auth, please see documentation for config help
@@ -22,8 +22,8 @@ $config['auth_mechanism'] = "mysql";    // default, other options: ldap, http-au
 // $config['poller-wrapper']['alerter'] = TRUE;
 
 // Set up a default alerter (email to a single address)
-$config['email']['default']        = "user@your-domain";
-$config['email']['from']           = "Observium <observium@your-domain>";
-$config['email']['default_only']   = TRUE;
+$config['email']['default']        = "{{ observium_admin_account_info.email_to | default('root@localhost') }}";
+$config['email']['from']           = "{{ observium_admin_account_info.email | default('root@localhost') }}";
+$config['email']['default_only']   = {{ observium_admin_account_info.email_default_only | default('TRUE') }};
 
 // End config.php


### PR DESCRIPTION
de email settings was fixed and didn't allow to change the contact information to send alerts, it is fixed now to allow to change it. 
Also added option to add a list of snmp default communities to use when adding devices.
