### PR TITLE
Fixing broken PHP and adding commercial option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ observium_monitor_libvirt_vms: false  #Define if desired to monitor LibVirt VM's
 pri_domain_name: 'vagrant.local'
 observium_snmp_community_list:   # define a list of default communities to try when adding devices
   - '"public"'    # requires that the quotes are inside single quotation marks to keep the quotes in the config.php
+
+# If we wish to use the paid for version this will allow us to use
+observium_commercial: false                                                                     # Do we wish to use opensource version
+observium_commercial_svn_user: ""                                                               # SVN user for commercial version
+observium_commercial_svn_password: ""                                                           # SVN password for commercial version
+observium_commercial_svn_repo: "http://svn.observium.org/svn/observium/branches/stable"         # Repo to pull commercial version from
 ````
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,3 +41,9 @@ observium_monitor_libvirt_vms: false  #Define if desired to monitor LibVirt VM's
 pri_domain_name: 'vagrant.local'
 observium_snmp_community_list:   # define a list of default communities to try when adding devices
   - '"public"'    # requires that the quotes are inside single quotation marks to keep the quotes in the config.php
+
+# If we wish to use the paid for version this will allow us to use
+observium_commercial: false                                                                     # Do we wish to use opensource version
+observium_commercial_svn_user: ""                                                               # SVN user for commercial version
+observium_commercial_svn_password: ""                                                           # SVN password for commercial version
+observium_commercial_svn_repo: "http://svn.observium.org/svn/observium/branches/stable"         # Repo to pull commercial version from

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,22 +18,22 @@ observium_debian_pre_reqs:
   - graphviz
   - imagemagick
   - ipmitool
-  - libapache2-mod-php5
+  - libapache2-mod-php
   - mtr-tiny
   - mysql-client
   - php-pear
-  - php5-cli
-  - php5-gd
-  - php5-json
-  - php5-mcrypt
-  - php5-mysql
+  - php7.0-cli
+  - php7.0-gd
+  - php7.0-json
+  - php7.0-mcrypt
+  - php7.0-mysql
   - python-mysqldb
   - rrdtool
   - snmp
   - subversion
   - whois
-  - php5-xcache # http://www.observium.org/docs/tuning/
-#  - mysql-server
+  - snmp-mibs-downloader
+
 observium_dl_dir: '/opt'
 observium_dl_package: 'observium-community-latest.tar.gz'
 observium_dl_url: 'http://www.observium.org'

--- a/tasks/install-commercial.yml
+++ b/tasks/install-commercial.yml
@@ -1,0 +1,25 @@
+---
+# This allows us to install the commercial version of observium
+
+- name: Force fail when svn user not defined
+  fail:
+    msg: "observium_commercial_svn_user variable is undefined, this means we cannot clone from observium SVN"
+  when: not observium_commercial_svn_user | length > 0
+
+- name: Force fail when svn password not defined
+  fail:
+    msg: "observium_commercial_svn_password variable is undefined, this means we cannot clone from observium SVN"
+  when: not observium_commercial_svn_password | length > 0
+
+- name: install-commercial | Downloading Observium to {{ observium_dl_dir }}
+  subversion:
+    repo: "{{ observium_commercial_svn_repo }}"
+    dest: "{{ observium_base_dir }}"
+    username: "{{ observium_commercial_svn_user }}"
+    password: "{{ observium_commercial_svn_password }}"
+
+# - name: install-commercial | Downloading Observium to {{ observium_dl_dir }}
+#   shell: "svn co --username '{{ observium_commercial_svn_user }}'  --password '{{ observium_commercial_svn_password }}' {{ observium_commercial_svn_repo }} {{ observium_base_dir }}"
+#   args:
+#     warn: false
+#     creates: "{{ observium_base_dir }}/poller.php"

--- a/tasks/install-commercial.yml
+++ b/tasks/install-commercial.yml
@@ -17,9 +17,4 @@
     dest: "{{ observium_base_dir }}"
     username: "{{ observium_commercial_svn_user }}"
     password: "{{ observium_commercial_svn_password }}"
-
-# - name: install-commercial | Downloading Observium to {{ observium_dl_dir }}
-#   shell: "svn co --username '{{ observium_commercial_svn_user }}'  --password '{{ observium_commercial_svn_password }}' {{ observium_commercial_svn_repo }} {{ observium_base_dir }}"
-#   args:
-#     warn: false
-#     creates: "{{ observium_base_dir }}/poller.php"
+    update: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,10 @@
   when: ansible_os_family == "Debian"
 
 - include: install.yml
+  when: not observium_commercial
+
+- include: install-commercial.yml
+  when: observium_commercial
 
 - include: config.yml
 


### PR DESCRIPTION
A couple of fixes and changes in this PR:

**Changing PHP5 to 7**
When using Ubuntu Xenial 16.04 the PHP5 does not appear to be working,
this is just a minor package change to fix this.

**Options to allow the usage of commercial version of Observium**
Added some extra variables to allow the usage of the paid for version of
Observium. It will require a username and password and the overriding of
observium_commercial variable to true. This will then use the commercial
version rather than the default community version.
No in place upgrades are performed